### PR TITLE
MIPS like ecalls

### DIFF
--- a/simulator/plugins/CallingConventionCheck.kt
+++ b/simulator/plugins/CallingConventionCheck.kt
@@ -208,7 +208,7 @@ class CallingConventionCheck(var returnOnlya0: Boolean = false) : SimulatorPlugi
     fun isCall(sim: Simulator, pre: PCDiff, post: PCDiff, mcode: MachineCode): Boolean {
         val inst = Instruction[mcode]
         return if (post.pc != pre.pc + mcode.length) {
-            inst.name == jal.name && sim.linkedProgram.prog.isAddrGlobalLabel(post.pc)
+            inst.name == jal.name && sim.linkedProgram.prog.isAddrGlobalLabel(post.pc) && mcode[InstructionField.RD] != Registers.zero 
         } else {
             false
         }


### PR DESCRIPTION
With this pull request, we add additional ecalls akin to often-used MIPS syscalls.
In our usage, we especially needed a call to read characters from the terminal.
For this purpose, we added the MIPS-like ecalls 6,8, and 12 to read an integer, a string, or a single character
as well as ecalls 0x130 and 0x131 to be compatible with the [VSCode Venus extension](https://github.com/hm-riscv/vscode-riscv-venus/tree/main?tab=readme-ov-file#terminal-ecall-0x130-and-0x131) (but in the standalone setting).
The ecalls 0x130 and 0x131 do not hinder the usage of the VSCode ones as they are caught first by the extension.

## Why address this fork?
Your [Venus fork](https://github.com/61c-teach/venus) seems to be one of the most up-to-date/feature-rich ones.
It contains a working build system to create a standalone jar file.
